### PR TITLE
chore(deps): bundle storage dep updates to avoid conflicts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,14 @@
     },
     {
       "packagePatterns": [
+        "^com.google.apis:google-api-services-storage",
+        "^com.google.cloud:google-cloud-storage"
+      ],
+      "semanticCommitType": "deps",
+      "semanticCommitScope": null
+    },
+    {
+      "packagePatterns": [
         "^com.google.cloud:google-cloud-"
       ],
       "ignoreUnstable": false

--- a/synth.py
+++ b/synth.py
@@ -20,4 +20,5 @@ AUTOSYNTH_MULTIPLE_COMMITS = True
 
 java.common_templates(excludes=[
     'README.md',
+    'renovate.json'
 ])


### PR DESCRIPTION
Issue observed when updating java-storage versions (https://github.com/googleapis/java-notification/runs/1519433891):
```
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for com.google.apis:google-api-services-storage:v1-rev20200927-1.30.10 paths to dependency are:
+-com.google.cloud:google-cloud-notification:0.121.3-beta-SNAPSHOT
  +-com.google.apis:google-api-services-storage:v1-rev20200927-1.30.10
and
+-com.google.cloud:google-cloud-notification:0.121.3-beta-SNAPSHOT
  +-com.google.cloud:google-cloud-storage:1.113.5
    +-com.google.apis:google-api-services-storage:v1-rev20201112-1.31.0
```