### PR TITLE
ci: removing linkage-monitor from required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,7 +10,6 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - dependencies (8)
       - dependencies (11)
-      - linkage-monitor
       - lint
       - clirr
       - units (8)
@@ -25,7 +24,6 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - dependencies (8)
       - dependencies (11)
-      - linkage-monitor
       - lint
       - clirr
       - units (7)


### PR DESCRIPTION
Somehow I missed to update the required checks of this repository when I was removing linkage-monitor from the required checks. Rectifying the configuration.

https://github.com/googleapis/java-notification/pull/413#issuecomment-918476342

@Neenu1995 

But I guess this PR requires "linkage-monitor" to be passed. Would you update the repository settings to remove "linkage-monitor" from the required checks?
