### PR TITLE
chore: manually exclude requirements.txt from renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     ":maintainLockFilesDisabled",
     ":autodetectPinVersions"
   ],
+  "ignorePaths": [".kokoro/requirements.txt"],
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
Manually brings in changes from https://github.com/googleapis/synthtool/pull/1594. [Renovate.json is excluded in owlbot](https://github.com/googleapis/java-notification/blob/4923b38c23dd7f275983fd59785d0f7c20172b66/owlbot.py#L23) so the changes in synthtool couldn't be applied. This is to stop update dep PRs like [this one](https://github.com/googleapis/java-notification/pull/735) from showing up in the repo.
